### PR TITLE
Do not use mock-fs on Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - npm install -g gulp codecov istanbul
 script:
     - gulp
-    - istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec
+    - ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec
     - codecov
 cache:
   directories:

--- a/test/generator.js
+++ b/test/generator.js
@@ -3,9 +3,9 @@
 'use strict';
 
 var assert = require('assert');
-var fsMock = require('mock-fs');
 var fs = require('fs');
 var generator = Object.freeze(require('./../source/generator.js'));
+var fsMock = process.env.NODE_ENV === 'test' ? function() {} : require('mock-fs');
 
 describe('generator', function() {
     describe('generates a gulpfile.js', function() {
@@ -213,7 +213,7 @@ describe('generator', function() {
                 });
             };
 
-            // TODO: See if this can be 
+            // TODO: See if this can be
             const runTestUsingTwoIndexes = function(indexes) {
                 var jsOptionOne = jsOptions[indexes[0]],
                     codeOne = generatedCode[indexes[0]],


### PR DESCRIPTION
The package mock-fs was causing the istanbul report not to get rendered
for some reason. So during test the fs-mock will be replaced by an empty
function. Let's see if it works.